### PR TITLE
Centering any iframe

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -964,3 +964,9 @@ footer .owner p a {
 .highlight .vg { color: #008080 } /* Name.Variable.Global */
 .highlight .vi { color: #008080 } /* Name.Variable.Instance */
 .highlight .il { color: #009999 } /* Literal.Number.Integer.Long */
+
+/*----------------------------Add----------------------------*/
+iframe{/*Centering any iframe*/
+  margin:auto;
+  display:block;
+}


### PR DESCRIPTION
iframe is used for embedding files like document, video player, music player, etc. I just simply relocate the iframe, any global iframe, to always be in the center of the page horizontally .
